### PR TITLE
fix(migrations): fix issue with cold start of migration schema

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
-## [0.3.10] - Unreleased
+## [0.3.11] - 2025-03-10
+### Fixed
+- Fixed an error with creating a migration file when a user doesn't have `supabase_migrations` schema
+
+
+## [0.3.10] - 2025-03-09
 ### Added
 - Enhanced migration naming system with improved object type detection for procedures, functions, and views.
 - Expanded `retrieve_migrations` tool with pagination, name pattern filtering, and option to include full SQL queries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 authors = [
     {name = "Alexander Zuev", email = "azuev@outlook.com"}
 ]
-keywords = ["supabase", "mcp", "cursor", "windsurf"]
+keywords = ["supabase", "mcp", "cursor", "windsurf", "model-context-protocol", "claude", "cline"]
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/supabase_mcp/services/database/sql/loader.py
+++ b/supabase_mcp/services/database/sql/loader.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from supabase_mcp.logger import logger
+
+
+class SQLLoader:
+    """Responsible for loading SQL queries from files."""
+
+    # Path to SQL files directory
+    SQL_DIR = Path(__file__).parent / "queries"
+
+    @classmethod
+    def load_sql(cls, filename: str) -> str:
+        """
+        Load SQL from a file in the sql directory.
+
+        Args:
+            filename: Name of the SQL file (with or without .sql extension)
+
+        Returns:
+            str: The SQL query from the file
+
+        Raises:
+            FileNotFoundError: If the SQL file doesn't exist
+        """
+        # Ensure the filename has .sql extension
+        if not filename.endswith(".sql"):
+            filename = f"{filename}.sql"
+
+        file_path = cls.SQL_DIR / filename
+
+        if not file_path.exists():
+            logger.error(f"SQL file not found: {file_path}")
+            raise FileNotFoundError(f"SQL file not found: {file_path}")
+
+        with open(file_path) as f:
+            sql = f.read().strip()
+            logger.debug(f"Loaded SQL file: {filename} ({len(sql)} chars)")
+            return sql
+
+    @classmethod
+    def get_schemas_query(cls) -> str:
+        """Get a query to list all schemas."""
+        return cls.load_sql("get_schemas")
+
+    @classmethod
+    def get_tables_query(cls, schema_name: str) -> str:
+        """Get a query to list all tables in a schema."""
+        query = cls.load_sql("get_tables")
+        return query.replace("{schema_name}", schema_name)
+
+    @classmethod
+    def get_table_schema_query(cls, schema_name: str, table: str) -> str:
+        """Get a query to get the schema of a table."""
+        query = cls.load_sql("get_table_schema")
+        return query.replace("{schema_name}", schema_name).replace("{table}", table)
+
+    @classmethod
+    def get_migrations_query(
+        cls, limit: int = 50, offset: int = 0, name_pattern: str = "", include_full_queries: bool = False
+    ) -> str:
+        """Get a query to list migrations."""
+        query = cls.load_sql("get_migrations")
+        return (
+            query.replace("{limit}", str(limit))
+            .replace("{offset}", str(offset))
+            .replace("{name_pattern}", name_pattern)
+            .replace("{include_full_queries}", str(include_full_queries).lower())
+        )
+
+    @classmethod
+    def get_init_migrations_query(cls) -> str:
+        """Get a query to initialize the migrations schema and table."""
+        return cls.load_sql("init_migrations")
+
+    @classmethod
+    def get_create_migration_query(cls, version: str, name: str, statements: str) -> str:
+        """Get a query to create a migration.
+
+        Args:
+            version: The migration version (timestamp)
+            name: The migration name
+            statements: The SQL statements (escaped)
+
+        Returns:
+            str: The SQL query to create a migration
+        """
+        query = cls.load_sql("create_migration")
+        return query.replace("{version}", version).replace("{name}", name).replace("{statements}", statements)

--- a/supabase_mcp/services/database/sql/queries/create_migration.sql
+++ b/supabase_mcp/services/database/sql/queries/create_migration.sql
@@ -1,0 +1,4 @@
+-- Create a migration
+INSERT INTO supabase_migrations.schema_migrations
+(version, name, statements)
+VALUES ('{version}', '{name}', ARRAY['{statements}']);

--- a/supabase_mcp/services/database/sql/queries/init_migrations.sql
+++ b/supabase_mcp/services/database/sql/queries/init_migrations.sql
@@ -1,0 +1,10 @@
+-- Initialize migrations infrastructure
+-- Create the migrations schema if it doesn't exist
+CREATE SCHEMA IF NOT EXISTS supabase_migrations;
+
+-- Create the migrations table if it doesn't exist
+CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
+    version TEXT PRIMARY KEY,
+    statements TEXT[] NOT NULL,
+    name TEXT NOT NULL
+);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,10 @@ from supabase_mcp.logger import logger
 from supabase_mcp.services.api.api_client import ManagementAPIClient
 from supabase_mcp.services.api.api_manager import SupabaseApiManager
 from supabase_mcp.services.api.spec_manager import ApiSpecManager
+from supabase_mcp.services.database.migration_manager import MigrationManager
 from supabase_mcp.services.database.postgres_client import PostgresClient
 from supabase_mcp.services.database.query_manager import QueryManager
+from supabase_mcp.services.database.sql.loader import SQLLoader
 from supabase_mcp.services.database.sql.validator import SQLValidator
 from supabase_mcp.services.safety.safety_manager import SafetyManager
 from supabase_mcp.services.sdk.sdk_client import SupabaseSDKClient
@@ -351,3 +353,15 @@ def tools_registry_integration(
     logger.info("✓ Tools registered with MCP server successfully.")
 
     return container
+
+
+@pytest.fixture
+def sql_loader() -> SQLLoader:
+    """Fixture providing a SQLLoader instance for tests."""
+    return SQLLoader()
+
+
+@pytest.fixture
+def migration_manager(sql_loader: SQLLoader) -> MigrationManager:
+    """Fixture providing a MigrationManager instance for tests."""
+    return MigrationManager(loader=sql_loader)

--- a/tests/services/database/sql/test_loader.py
+++ b/tests/services/database/sql/test_loader.py
@@ -1,0 +1,103 @@
+import os
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from supabase_mcp.services.database.sql.loader import SQLLoader
+
+
+@pytest.mark.unit
+class TestSQLLoader:
+    """Unit tests for the SQLLoader class."""
+
+    def test_load_sql_with_extension(self):
+        """Test loading SQL with file extension provided."""
+        mock_sql = "SELECT * FROM test;"
+
+        with patch("builtins.open", mock_open(read_data=mock_sql)):
+            with patch.object(Path, "exists", return_value=True):
+                result = SQLLoader.load_sql("test.sql")
+
+        assert result == mock_sql
+
+    def test_load_sql_without_extension(self):
+        """Test loading SQL without file extension provided."""
+        mock_sql = "SELECT * FROM test;"
+
+        with patch("builtins.open", mock_open(read_data=mock_sql)):
+            with patch.object(Path, "exists", return_value=True):
+                result = SQLLoader.load_sql("test")
+
+        assert result == mock_sql
+
+    def test_load_sql_file_not_found(self):
+        """Test loading SQL when file doesn't exist."""
+        with patch.object(Path, "exists", return_value=False):
+            with pytest.raises(FileNotFoundError):
+                SQLLoader.load_sql("nonexistent")
+
+    def test_get_schemas_query(self):
+        """Test getting schemas query."""
+        mock_sql = "SELECT * FROM schemas;"
+
+        with patch.object(SQLLoader, "load_sql", return_value=mock_sql):
+            result = SQLLoader.get_schemas_query()
+
+        assert result == mock_sql
+
+    def test_get_tables_query(self):
+        """Test getting tables query with schema replacement."""
+        mock_sql = "SELECT * FROM {schema_name}.tables;"
+        expected = "SELECT * FROM test_schema.tables;"
+
+        with patch.object(SQLLoader, "load_sql", return_value=mock_sql):
+            result = SQLLoader.get_tables_query("test_schema")
+
+        assert result == expected
+
+    def test_get_table_schema_query(self):
+        """Test getting table schema query with replacements."""
+        mock_sql = "SELECT * FROM {schema_name}.{table};"
+        expected = "SELECT * FROM test_schema.test_table;"
+
+        with patch.object(SQLLoader, "load_sql", return_value=mock_sql):
+            result = SQLLoader.get_table_schema_query("test_schema", "test_table")
+
+        assert result == expected
+
+    def test_get_migrations_query(self):
+        """Test getting migrations query with all parameters."""
+        mock_sql = "SELECT * FROM migrations WHERE name LIKE '%{name_pattern}%' LIMIT {limit} OFFSET {offset} AND include_queries = {include_full_queries};"
+        expected = "SELECT * FROM migrations WHERE name LIKE '%test%' LIMIT 10 OFFSET 5 AND include_queries = true;"
+
+        with patch.object(SQLLoader, "load_sql", return_value=mock_sql):
+            result = SQLLoader.get_migrations_query(limit=10, offset=5, name_pattern="test", include_full_queries=True)
+
+        assert result == expected
+
+    def test_get_init_migrations_query(self):
+        """Test getting init migrations query."""
+        mock_sql = "CREATE SCHEMA IF NOT EXISTS migrations;"
+
+        with patch.object(SQLLoader, "load_sql", return_value=mock_sql):
+            result = SQLLoader.get_init_migrations_query()
+
+        assert result == mock_sql
+
+    def test_get_create_migration_query(self):
+        """Test getting create migration query with replacements."""
+        mock_sql = "INSERT INTO migrations VALUES ('{version}', '{name}', ARRAY['{statements}']);"
+        expected = "INSERT INTO migrations VALUES ('20230101', 'test_migration', ARRAY['SELECT 1;']);"
+
+        with patch.object(SQLLoader, "load_sql", return_value=mock_sql):
+            result = SQLLoader.get_create_migration_query(
+                version="20230101", name="test_migration", statements="SELECT 1;"
+            )
+
+        assert result == expected
+
+    def test_sql_dir_path(self):
+        """Test that SQL_DIR points to the correct location."""
+        expected_path = Path(SQLLoader.__module__.replace(".", os.sep)).parent / "queries"
+        assert str(SQLLoader.SQL_DIR).endswith(str(expected_path))

--- a/tests/services/database/test_migration_manager.py
+++ b/tests/services/database/test_migration_manager.py
@@ -7,14 +7,8 @@ from supabase_mcp.services.database.sql.validator import SQLValidator
 
 
 @pytest.fixture
-def validator() -> SQLValidator:
-    """Create a SQLValidator instance for testing."""
-    return SQLValidator()
-
-
-@pytest.fixture
 def sample_ddl_queries() -> dict[str, str]:
-    """Sample DDL (CREATE, ALTER, DROP) queries for testing."""
+    """Return a dictionary of sample DDL queries for testing."""
     return {
         "create_table": "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT, email TEXT UNIQUE)",
         "create_table_with_schema": "CREATE TABLE public.users (id SERIAL PRIMARY KEY, name TEXT, email TEXT UNIQUE)",
@@ -52,104 +46,108 @@ class TestMigrationManager:
     """Tests for the MigrationManager class."""
 
     def test_generate_descriptive_name_with_default_schema(
-        self, validator: SQLValidator, sample_ddl_queries: dict[str, str]
+        self, mock_validator: SQLValidator, sample_ddl_queries: dict[str, str], migration_manager: MigrationManager
     ):
         """Test generating a descriptive name with default schema."""
         # Use the create_table query from fixtures (no explicit schema)
-        result = validator.validate_query(sample_ddl_queries["create_table"])
+        result = mock_validator.validate_query(sample_ddl_queries["create_table"])
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name follows the expected format with default schema
         assert name == "create_users_public_unknown"
 
     def test_generate_descriptive_name_with_explicit_schema(
-        self, validator: SQLValidator, sample_ddl_queries: dict[str, str]
+        self, mock_validator: SQLValidator, sample_ddl_queries: dict[str, str], migration_manager: MigrationManager
     ):
         """Test generating a descriptive name with explicit schema."""
         # Use the create_table_with_schema query from fixtures
-        result = validator.validate_query(sample_ddl_queries["create_table_with_schema"])
+        result = mock_validator.validate_query(sample_ddl_queries["create_table_with_schema"])
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name follows the expected format with explicit schema
         assert name == "create_users_public_unknown"
 
     def test_generate_descriptive_name_with_custom_schema(
-        self, validator: SQLValidator, sample_ddl_queries: dict[str, str]
+        self, mock_validator: SQLValidator, sample_ddl_queries: dict[str, str], migration_manager: MigrationManager
     ):
         """Test generating a descriptive name with custom schema."""
         # Use the create_table_custom_schema query from fixtures
-        result = validator.validate_query(sample_ddl_queries["create_table_custom_schema"])
+        result = mock_validator.validate_query(sample_ddl_queries["create_table_custom_schema"])
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name follows the expected format with custom schema
         assert name == "create_users_app_unknown"
 
     def test_generate_descriptive_name_with_multiple_statements(
-        self, validator: SQLValidator, sample_multiple_statements: dict[str, str]
+        self,
+        mock_validator: SQLValidator,
+        sample_multiple_statements: dict[str, str],
+        migration_manager: MigrationManager,
     ):
         """Test generating a descriptive name with multiple statements."""
         # Use the multiple_ddl query from fixtures
-        result = validator.validate_query(sample_multiple_statements["multiple_ddl"])
+        result = mock_validator.validate_query(sample_multiple_statements["multiple_ddl"])
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name is based on the first non-TCL statement that needs migration
         assert name == "create_users_public_users"
 
     def test_generate_descriptive_name_with_mixed_statements(
-        self, validator: SQLValidator, sample_multiple_statements: dict[str, str]
+        self,
+        mock_validator: SQLValidator,
+        sample_multiple_statements: dict[str, str],
+        migration_manager: MigrationManager,
     ):
         """Test generating a descriptive name with mixed statements."""
         # Use the mixed_with_migration query from fixtures
-        result = validator.validate_query(sample_multiple_statements["mixed_with_migration"])
+        result = mock_validator.validate_query(sample_multiple_statements["mixed_with_migration"])
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name is based on the first statement that needs migration (skipping SELECT)
         assert name == "create_logs_public_logs"
 
     def test_generate_descriptive_name_with_no_migration_statements(
-        self, validator: SQLValidator, sample_multiple_statements: dict[str, str]
+        self,
+        mock_validator: SQLValidator,
+        sample_multiple_statements: dict[str, str],
+        migration_manager: MigrationManager,
     ):
         """Test generating a descriptive name with no statements that need migration."""
         # Use the only_select query from fixtures (renamed from only_tcl)
-        result = validator.validate_query(sample_multiple_statements["only_select"])
+        result = mock_validator.validate_query(sample_multiple_statements["only_select"])
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that a generic name is generated
         assert re.match(r"migration_\w+", name)
 
     def test_generate_descriptive_name_for_alter_table(
-        self, validator: SQLValidator, sample_ddl_queries: dict[str, str]
+        self, mock_validator: SQLValidator, sample_ddl_queries: dict[str, str], migration_manager: MigrationManager
     ):
         """Test generating a descriptive name for ALTER TABLE statements."""
         # Use the alter_table query from fixtures
-        result = validator.validate_query(sample_ddl_queries["alter_table"])
+        result = mock_validator.validate_query(sample_ddl_queries["alter_table"])
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name follows the expected format for ALTER TABLE
         assert name == "alter_users_public_unknown"
 
-    def test_generate_descriptive_name_for_create_function(self, validator: SQLValidator):
+    def test_generate_descriptive_name_for_create_function(
+        self, mock_validator: SQLValidator, migration_manager: MigrationManager
+    ):
         """Test generating a descriptive name for CREATE FUNCTION statements."""
         # Define a CREATE FUNCTION query
         function_query = """
@@ -164,16 +162,17 @@ class TestMigrationManager:
         $$ LANGUAGE plpgsql SECURITY DEFINER;
         """
 
-        result = validator.validate_query(function_query)
+        result = mock_validator.validate_query(function_query)
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name follows the expected format for CREATE FUNCTION
         assert name == "create_function_public_user_role"
 
-    def test_generate_descriptive_name_with_comments(self, validator: SQLValidator):
+    def test_generate_descriptive_name_with_comments(
+        self, mock_validator: SQLValidator, migration_manager: MigrationManager
+    ):
         """Test generating a descriptive name for SQL with comments."""
         # Define a query with various types of comments
         query_with_comments = """
@@ -189,55 +188,50 @@ class TestMigrationManager:
         -- This is a comment at the end
         """
 
-        result = validator.validate_query(query_with_comments)
+        result = mock_validator.validate_query(query_with_comments)
 
-        # Create a migration manager and generate a name
-        mm = MigrationManager()
-        name = mm.generate_descriptive_name(result)
+        # Generate a name using the migration manager fixture
+        name = migration_manager.generate_descriptive_name(result)
 
         # Check that the name is correctly generated despite the comments
         assert name == "create_comments_public_comments"
 
-    def test_sanitize_name(self):
+    def test_sanitize_name(self, migration_manager: MigrationManager):
         """Test the sanitize_name method with various inputs."""
-        mm = MigrationManager()
-
         # Test with simple name
-        assert mm.sanitize_name("simple_name") == "simple_name"
+        assert migration_manager.sanitize_name("simple_name") == "simple_name"
 
         # Test with spaces
-        assert mm.sanitize_name("name with spaces") == "name_with_spaces"
+        assert migration_manager.sanitize_name("name with spaces") == "name_with_spaces"
 
         # Test with special characters
-        assert mm.sanitize_name("name-with!special@chars#") == "namewithspecialchars"
+        assert migration_manager.sanitize_name("name-with!special@chars#") == "namewithspecialchars"
 
         # Test with uppercase
-        assert mm.sanitize_name("UPPERCASE_NAME") == "uppercase_name"
+        assert migration_manager.sanitize_name("UPPERCASE_NAME") == "uppercase_name"
 
         # Test with very long name (over 100 chars)
         long_name = "a" * 150
-        assert len(mm.sanitize_name(long_name)) == 100
+        assert len(migration_manager.sanitize_name(long_name)) == 100
 
         # Test with mixed case and special chars
-        assert mm.sanitize_name("User-Profile_Table!") == "userprofile_table"
+        assert migration_manager.sanitize_name("User-Profile_Table!") == "userprofile_table"
 
-    def test_prepare_migration_query(self, validator: SQLValidator):
+    def test_prepare_migration_query(self, mock_validator: SQLValidator, migration_manager: MigrationManager):
         """Test the prepare_migration_query method."""
         # Create a sample query and validate it
         query = "CREATE TABLE test_table (id SERIAL PRIMARY KEY);"
-        result = validator.validate_query(query)
-
-        mm = MigrationManager()
+        result = mock_validator.validate_query(query)
 
         # Test with client-provided name
-        migration_query, name = mm.prepare_migration_query(result, query, "my_custom_migration")
+        migration_query, name = migration_manager.prepare_migration_query(result, query, "my_custom_migration")
         assert name == "my_custom_migration"
         assert "INSERT INTO supabase_migrations.schema_migrations" in migration_query
         assert "my_custom_migration" in migration_query
         assert query.replace("'", "''") in migration_query
 
         # Test with auto-generated name
-        migration_query, name = mm.prepare_migration_query(result, query)
+        migration_query, name = migration_manager.prepare_migration_query(result, query)
         assert name  # Name should not be empty
         assert "INSERT INTO supabase_migrations.schema_migrations" in migration_query
         assert name in migration_query
@@ -245,17 +239,15 @@ class TestMigrationManager:
 
         # Test with query containing single quotes (SQL injection prevention)
         query_with_quotes = "INSERT INTO users (name) VALUES ('O''Brien');"
-        result = validator.validate_query(query_with_quotes)
-        migration_query, _ = mm.prepare_migration_query(result, query_with_quotes)
+        result = mock_validator.validate_query(query_with_quotes)
+        migration_query, _ = migration_manager.prepare_migration_query(result, query_with_quotes)
         # The single quotes are already escaped in the original query, and they get escaped again
         assert "VALUES (''O''''Brien'')" in migration_query
 
-    def test_generate_short_hash(self):
+    def test_generate_short_hash(self, migration_manager: MigrationManager):
         """Test the _generate_short_hash method."""
-        mm = MigrationManager()
-
         # Use getattr to access protected method
-        generate_short_hash = getattr(mm, "_generate_short_hash")  # noqa
+        generate_short_hash = getattr(migration_manager, "_generate_short_hash")  # noqa
 
         # Test with simple string
         hash1 = generate_short_hash("test string")
@@ -274,21 +266,20 @@ class TestMigrationManager:
         hash4 = generate_short_hash("different string")
         assert hash1 != hash4
 
-    def test_generate_dml_name(self, validator: SQLValidator):
+    def test_generate_dml_name(self, mock_validator: SQLValidator, migration_manager: MigrationManager):
         """Test the _generate_dml_name method."""
-        mm = MigrationManager()
-        generate_dml_name = getattr(mm, "_generate_dml_name")  # noqa
+        generate_dml_name = getattr(migration_manager, "_generate_dml_name")  # noqa
 
         # Test INSERT statement
         insert_query = "INSERT INTO users (name, email) VALUES ('John', 'john@example.com');"
-        result = validator.validate_query(insert_query)
+        result = mock_validator.validate_query(insert_query)
         statement = result.statements[0]
         name = generate_dml_name(statement)
         assert name == "insert_public_users"
 
         # Test UPDATE statement with column extraction
         update_query = "UPDATE users SET name = 'John', email = 'john@example.com' WHERE id = 1;"
-        result = validator.validate_query(update_query)
+        result = mock_validator.validate_query(update_query)
         statement = result.statements[0]
         name = generate_dml_name(statement)
         assert "update" in name
@@ -296,19 +287,18 @@ class TestMigrationManager:
 
         # Test DELETE statement
         delete_query = "DELETE FROM users WHERE id = 1;"
-        result = validator.validate_query(delete_query)
+        result = mock_validator.validate_query(delete_query)
         statement = result.statements[0]
         name = generate_dml_name(statement)
         assert name == "delete_public_users"
 
-    def test_generate_dcl_name(self, validator: SQLValidator):
+    def test_generate_dcl_name(self, mock_validator: SQLValidator, migration_manager: MigrationManager):
         """Test the _generate_dcl_name method."""
-        mm = MigrationManager()
-        generate_dcl_name = getattr(mm, "_generate_dcl_name")  # noqa
+        generate_dcl_name = getattr(migration_manager, "_generate_dcl_name")  # noqa
 
         # Test GRANT statement
         grant_query = "GRANT SELECT ON users TO anon;"
-        result = validator.validate_query(grant_query)
+        result = mock_validator.validate_query(grant_query)
         statement = result.statements[0]
         name = generate_dcl_name(statement)
         assert "grant" in name
@@ -317,7 +307,7 @@ class TestMigrationManager:
 
         # Test REVOKE statement
         revoke_query = "REVOKE ALL ON users FROM anon;"
-        result = validator.validate_query(revoke_query)
+        result = mock_validator.validate_query(revoke_query)
         statement = result.statements[0]
         name = generate_dcl_name(statement)
         # The implementation doesn't actually use the command from the statement
@@ -325,10 +315,9 @@ class TestMigrationManager:
         assert "all" in name
         assert "users" in name
 
-    def test_extract_table_name(self):
+    def test_extract_table_name(self, migration_manager: MigrationManager):
         """Test the _extract_table_name method."""
-        mm = MigrationManager()
-        extract_table_name = getattr(mm, "_extract_table_name")  # noqa
+        extract_table_name = getattr(migration_manager, "_extract_table_name")  # noqa
 
         # Test CREATE TABLE
         assert extract_table_name("CREATE TABLE users (id SERIAL PRIMARY KEY);") == "users"
@@ -353,10 +342,9 @@ class TestMigrationManager:
         assert extract_table_name("") == "unknown"
         assert extract_table_name("SELECT * FROM users;") == "unknown"  # Not handled by this method
 
-    def test_extract_function_name(self):
+    def test_extract_function_name(self, migration_manager: MigrationManager):
         """Test the _extract_function_name method."""
-        mm = MigrationManager()
-        extract_function_name = getattr(mm, "_extract_function_name")  # noqa
+        extract_function_name = getattr(migration_manager, "_extract_function_name")  # noqa
 
         # Test CREATE FUNCTION
         assert (
@@ -390,10 +378,9 @@ class TestMigrationManager:
         assert extract_function_name("") == "unknown"
         assert extract_function_name("SELECT * FROM users;") == "unknown"
 
-    def test_extract_view_name(self):
+    def test_extract_view_name(self, migration_manager: MigrationManager):
         """Test the _extract_view_name method."""
-        mm = MigrationManager()
-        extract_view_name = getattr(mm, "_extract_view_name")  # noqa
+        extract_view_name = getattr(migration_manager, "_extract_view_name")  # noqa
 
         # Test CREATE VIEW
         assert extract_view_name("CREATE VIEW user_view AS SELECT * FROM users;") == "user_view"
@@ -412,10 +399,9 @@ class TestMigrationManager:
         assert extract_view_name("") == "unknown"
         assert extract_view_name("SELECT * FROM users;") == "unknown"
 
-    def test_extract_index_name(self):
+    def test_extract_index_name(self, migration_manager: MigrationManager):
         """Test the _extract_index_name method."""
-        mm = MigrationManager()
-        extract_index_name = getattr(mm, "_extract_index_name")  # noqa
+        extract_index_name = getattr(migration_manager, "_extract_index_name")  # noqa
 
         # Test CREATE INDEX
         assert extract_index_name("CREATE INDEX idx_user_email ON users (email);") == "idx_user_email"
@@ -436,10 +422,9 @@ class TestMigrationManager:
         assert extract_index_name("") == "unknown"
         assert extract_index_name("SELECT * FROM users;") == "unknown"
 
-    def test_extract_extension_name(self):
+    def test_extract_extension_name(self, migration_manager: MigrationManager):
         """Test the _extract_extension_name method."""
-        mm = MigrationManager()
-        extract_extension_name = getattr(mm, "_extract_extension_name")  # noqa
+        extract_extension_name = getattr(migration_manager, "_extract_extension_name")  # noqa
 
         # Test CREATE EXTENSION
         assert extract_extension_name("CREATE EXTENSION pgcrypto;") == "pgcrypto"
@@ -462,10 +447,9 @@ class TestMigrationManager:
         assert extract_extension_name("") == "unknown"
         assert extract_extension_name("SELECT * FROM users;") == "unknown"
 
-    def test_extract_type_name(self):
+    def test_extract_type_name(self, migration_manager: MigrationManager):
         """Test the _extract_type_name method."""
-        mm = MigrationManager()
-        extract_type_name = getattr(mm, "_extract_type_name")  # noqa
+        extract_type_name = getattr(migration_manager, "_extract_type_name")  # noqa
 
         # Test CREATE TYPE (ENUM)
         assert (
@@ -502,10 +486,9 @@ class TestMigrationManager:
         assert extract_type_name("") == "unknown"
         assert extract_type_name("SELECT * FROM users;") == "unknown"
 
-    def test_extract_update_columns(self):
+    def test_extract_update_columns(self, migration_manager: MigrationManager):
         """Test the _extract_update_columns method."""
-        mm = MigrationManager()
-        extract_update_columns = getattr(mm, "_extract_update_columns")  # noqa
+        extract_update_columns = getattr(migration_manager, "_extract_update_columns")  # noqa
 
         # The current implementation seems to have issues with the regex pattern
         # Let's test what it actually returns rather than what we expect
@@ -530,10 +513,9 @@ class TestMigrationManager:
         # Test with a query that doesn't match the regex pattern
         assert extract_update_columns("UPDATE users SET name = 'John'") == ""
 
-    def test_extract_privilege(self):
+    def test_extract_privilege(self, migration_manager: MigrationManager):
         """Test the _extract_privilege method."""
-        mm = MigrationManager()
-        extract_privilege = getattr(mm, "_extract_privilege")  # noqa
+        extract_privilege = getattr(migration_manager, "_extract_privilege")  # noqa
 
         # Test with SELECT privilege
         assert extract_privilege("GRANT SELECT ON users TO anon;") == "select"
@@ -562,10 +544,9 @@ class TestMigrationManager:
         assert extract_privilege("") == "privilege"
         assert extract_privilege("SELECT * FROM users;") == "privilege"
 
-    def test_extract_dcl_object_name(self):
+    def test_extract_dcl_object_name(self, migration_manager: MigrationManager):
         """Test the _extract_dcl_object_name method."""
-        mm = MigrationManager()
-        extract_dcl_object_name = getattr(mm, "_extract_dcl_object_name")  # noqa
+        extract_dcl_object_name = getattr(migration_manager, "_extract_dcl_object_name")  # noqa
 
         # Test with table
         assert extract_dcl_object_name("GRANT SELECT ON users TO anon;") == "users"
@@ -581,10 +562,9 @@ class TestMigrationManager:
         assert extract_dcl_object_name("") == "unknown"
         assert extract_dcl_object_name("SELECT * FROM users;") == "unknown"
 
-    def test_extract_generic_object_name(self):
+    def test_extract_generic_object_name(self, migration_manager: MigrationManager):
         """Test the _extract_generic_object_name method."""
-        mm = MigrationManager()
-        extract_generic_object_name = getattr(mm, "_extract_generic_object_name")  # noqa
+        extract_generic_object_name = getattr(migration_manager, "_extract_generic_object_name")  # noqa
 
         # Test with CREATE statement
         assert extract_generic_object_name("CREATE SCHEMA app;") == "app"
@@ -613,12 +593,10 @@ class TestMigrationManager:
         assert extract_generic_object_name("") == "unknown"
         assert extract_generic_object_name("BEGIN;") == "unknown"
 
-    def test_generate_query_timestamp(self):
+    def test_generate_query_timestamp(self, migration_manager: MigrationManager):
         """Test the generate_query_timestamp method."""
-        mm = MigrationManager()
-
         # Get timestamp
-        timestamp = mm.generate_query_timestamp()
+        timestamp = migration_manager.generate_query_timestamp()
 
         # Verify format (YYYYMMDDHHMMSS)
         assert len(timestamp) == 14
@@ -634,3 +612,80 @@ class TestMigrationManager:
             is_valid = False
 
         assert is_valid
+
+    def test_init_migrations_sql_idempotency(self, migration_manager: MigrationManager):
+        """Test that the init_migrations.sql file is idempotent and handles non-existent schema."""
+        # Get the initialization query from the loader
+        init_query = migration_manager.loader.get_init_migrations_query()
+
+        # Verify it contains CREATE SCHEMA IF NOT EXISTS
+        assert "CREATE SCHEMA IF NOT EXISTS supabase_migrations" in init_query
+
+        # Verify it contains CREATE TABLE IF NOT EXISTS
+        assert "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations" in init_query
+
+        # Verify it defines the required columns
+        assert "version TEXT PRIMARY KEY" in init_query
+        assert "statements TEXT[] NOT NULL" in init_query
+        assert "name TEXT NOT NULL" in init_query
+
+        # The SQL should be idempotent - running it multiple times should be safe
+        # This is achieved with IF NOT EXISTS clauses
+
+    def test_create_migration_query(self, migration_manager: MigrationManager):
+        """Test that the create_migration.sql file correctly inserts a migration record."""
+        # Define test values
+        version = "20230101000000"
+        name = "test_migration"
+        statements = "CREATE TABLE test (id INT);"
+
+        # Get the create migration query
+        create_query = migration_manager.loader.get_create_migration_query(version, name, statements)
+
+        # Verify it contains an INSERT statement
+        assert "INSERT INTO supabase_migrations.schema_migrations" in create_query
+
+        # Verify it includes the version, name, and statements
+        assert version in create_query
+        assert name in create_query
+        assert statements in create_query
+
+        # Verify it's using the ARRAY constructor for statements
+        assert "ARRAY[" in create_query
+
+    def test_migration_system_handles_nonexistent_schema(
+        self, migration_manager: MigrationManager, mock_validator: SQLValidator
+    ):
+        """Test that the migration system correctly handles the case when the migration schema doesn't exist."""
+        # This test verifies that the QueryManager's init_migration_schema method
+        # is called before attempting to create a migration, ensuring that the
+        # schema and table exist before trying to insert into them.
+
+        # In a real system, when the migration schema doesn't exist:
+        # 1. The QueryManager would call init_migration_schema
+        # 2. The init_migration_schema method would execute the init_migrations.sql query
+        # 3. This would create the schema and table with IF NOT EXISTS clauses
+        # 4. Then the create_migration query would be executed
+
+        # For this test, we'll verify that:
+        # 1. The init_migrations.sql query creates the schema and table with IF NOT EXISTS
+        # 2. The create_migration.sql query assumes the table exists
+
+        # Get the initialization query
+        init_query = migration_manager.loader.get_init_migrations_query()
+
+        # Verify it creates the schema and table with IF NOT EXISTS
+        assert "CREATE SCHEMA IF NOT EXISTS" in init_query
+        assert "CREATE TABLE IF NOT EXISTS" in init_query
+
+        # Get a create migration query
+        version = migration_manager.generate_query_timestamp()
+        name = "test_migration"
+        statements = "CREATE TABLE test (id INT);"
+        create_query = migration_manager.loader.get_create_migration_query(version, name, statements)
+
+        # Verify it assumes the table exists (no IF EXISTS check)
+        assert "INSERT INTO supabase_migrations.schema_migrations" in create_query
+
+        # This is why the QueryManager needs to call init_migration_schema before
+        # attempting to create a migration - to ensure the table exists

--- a/tests/services/database/test_query_manager.py
+++ b/tests/services/database/test_query_manager.py
@@ -1,27 +1,33 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from supabase_mcp.exceptions import SafetyError
 from supabase_mcp.services.database.query_manager import QueryManager
+from supabase_mcp.services.database.sql.loader import SQLLoader
 from supabase_mcp.services.database.sql.validator import (
     QueryValidationResults,
     SQLQueryCategory,
     SQLQueryCommand,
+    SQLValidator,
     ValidatedStatement,
 )
-from supabase_mcp.services.safety.models import OperationRiskLevel
+from supabase_mcp.services.safety.models import ClientType, OperationRiskLevel
 
 
+@pytest.mark.asyncio(loop_scope="module")
 class TestQueryManager:
     """Tests for the Query Manager."""
 
-    @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_query_execution(self, mock_query_manager: QueryManager):
         """Test query execution through the Query Manager."""
 
         query_manager = mock_query_manager
+
+        # Ensure validator and safety_manager are proper mocks
+        query_manager.validator = MagicMock()
+        query_manager.safety_manager = MagicMock()
 
         # Create a mock validation result for a SELECT query
         validated_statement = ValidatedStatement(
@@ -46,18 +52,19 @@ class TestQueryManager:
 
         # Make the db_client return a mock query result
         mock_query_result = MagicMock()
-        query_manager.db_client.execute_query_async.return_value = mock_query_result
+        query_manager.db_client.execute_query = AsyncMock(return_value=mock_query_result)
 
         # Execute a query
         query = "SELECT * FROM users"
         result = await query_manager.handle_query(query)
 
-        # Verify the query was processed correctly
+        # Verify the validator was called with the query
         query_manager.validator.validate_query.assert_called_once_with(query)
-        query_manager.safety_manager.validate_operation.assert_called_once()
-        query_manager.db_client.execute_query_async.assert_called_once()
 
-        # Verify that the result is what we expected
+        # Verify the db_client was called with the validation result
+        query_manager.db_client.execute_query.assert_called_once_with(validation_result, False)
+
+        # Verify the result is what we expect
         assert result == mock_query_result
 
     @pytest.mark.asyncio
@@ -68,11 +75,15 @@ class TestQueryManager:
         # Create a query manager with the mock dependencies
         query_manager = mock_query_manager
 
+        # Ensure validator and safety_manager are proper mocks
+        query_manager.validator = MagicMock()
+        query_manager.safety_manager = MagicMock()
+
         # Create a mock validation result for a DROP TABLE query
         validated_statement = ValidatedStatement(
             category=SQLQueryCategory.DDL,
             command=SQLQueryCommand.DROP,
-            risk_level=OperationRiskLevel.HIGH,
+            risk_level=OperationRiskLevel.EXTREME,
             query="DROP TABLE users",
             needs_migration=False,
             object_type="TABLE",
@@ -81,7 +92,7 @@ class TestQueryManager:
 
         validation_result = QueryValidationResults(
             statements=[validated_statement],
-            highest_risk_level=OperationRiskLevel.HIGH,
+            highest_risk_level=OperationRiskLevel.EXTREME,
             has_transaction_control=False,
             original_query="DROP TABLE users",
         )
@@ -90,16 +101,146 @@ class TestQueryManager:
         query_manager.validator.validate_query.return_value = validation_result
 
         # Make the safety manager raise a SafetyError
-        query_manager.safety_manager.validate_operation.side_effect = SafetyError("Operation not allowed")
+        error_message = "Operation not allowed in SAFE mode"
+        query_manager.safety_manager.validate_operation.side_effect = SafetyError(error_message)
 
-        # The handle_query method should raise the SafetyError
+        # Execute a query - should raise a SafetyError
+        query = "DROP TABLE users"
         with pytest.raises(SafetyError) as excinfo:
-            await query_manager.handle_query("DROP TABLE users")
+            await query_manager.handle_query(query)
 
         # Verify the error message
-        assert "Operation not allowed" in str(excinfo.value)
+        assert error_message in str(excinfo.value)
 
-        # Verify the query was validated but not executed
-        query_manager.validator.validate_query.assert_called_once()
-        query_manager.safety_manager.validate_operation.assert_called_once()
-        query_manager.db_client.execute_query_async.assert_not_called()
+        # Verify the validator was called with the query
+        query_manager.validator.validate_query.assert_called_once_with(query)
+
+        # Verify the safety manager was called with the validation result
+        query_manager.safety_manager.validate_operation.assert_called_once_with(
+            ClientType.DATABASE, validation_result, False
+        )
+
+        # Verify the db_client was not called
+        query_manager.db_client.execute_query.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_get_migrations_query(self, query_manager_integration: QueryManager):
+        """Test that get_migrations_query returns a valid query string."""
+        # Test with default parameters
+        query = query_manager_integration.get_migrations_query()
+        assert isinstance(query, str)
+        assert "supabase_migrations.schema_migrations" in query
+        assert "LIMIT 50" in query
+
+        # Test with custom parameters
+        custom_query = query_manager_integration.get_migrations_query(
+            limit=10, offset=5, name_pattern="test", include_full_queries=True
+        )
+        assert isinstance(custom_query, str)
+        assert "supabase_migrations.schema_migrations" in custom_query
+        assert "LIMIT 10" in custom_query
+        assert "OFFSET 5" in custom_query
+        assert "name ILIKE" in custom_query
+        assert "statements" in custom_query  # Should include statements column when include_full_queries=True
+
+    @pytest.mark.unit
+    async def test_init_migration_schema(self):
+        """Test that init_migration_schema initializes the migration schema correctly."""
+        # Create minimal mocks
+        postgres_client = MagicMock()
+        postgres_client.execute_query = AsyncMock()
+
+        safety_manager = MagicMock()
+
+        # Create a real SQLLoader and SQLValidator
+        sql_loader = SQLLoader()
+        sql_validator = SQLValidator()
+
+        # Create the QueryManager with minimal mocking
+        query_manager = QueryManager(
+            postgres_client=postgres_client,
+            safety_manager=safety_manager,
+            sql_validator=sql_validator,
+            sql_loader=sql_loader,
+        )
+
+        # Call the method
+        await query_manager.init_migration_schema()
+
+        # Verify that the SQL loader was used to get the init migrations query
+        # and that the query was executed
+        assert postgres_client.execute_query.called
+
+        # Get the arguments that execute_query was called with
+        call_args = postgres_client.execute_query.call_args
+        assert call_args is not None
+
+        # The first argument should be a QueryValidationResults object
+        args, _ = call_args  # Use _ to ignore unused kwargs
+        assert len(args) > 0
+        validation_result = args[0]
+        assert isinstance(validation_result, QueryValidationResults)
+
+        # Check that the validation result contains the expected SQL
+        init_query = sql_loader.get_init_migrations_query()
+        assert any(stmt.query and stmt.query in init_query for stmt in validation_result.statements)
+
+    @pytest.mark.unit
+    async def test_handle_migration(self):
+        """Test that handle_migration correctly handles migrations when needed."""
+        # Create minimal mocks
+        postgres_client = MagicMock()
+        postgres_client.execute_query = AsyncMock()
+
+        safety_manager = MagicMock()
+
+        # Create a real SQLLoader
+        sql_loader = SQLLoader()
+
+        # Create a mock MigrationManager
+        migration_manager = MagicMock()
+        migration_query = "INSERT INTO _migrations.migrations (name) VALUES ('test_migration')"
+        migration_name = "test_migration"
+        migration_manager.prepare_migration_query.return_value = (migration_query, migration_name)
+
+        # Create a real SQLValidator
+        sql_validator = SQLValidator()
+
+        # Create the QueryManager with minimal mocking
+        query_manager = QueryManager(
+            postgres_client=postgres_client,
+            safety_manager=safety_manager,
+            sql_validator=sql_validator,
+            sql_loader=sql_loader,
+            migration_manager=migration_manager,
+        )
+
+        # Create a validation result that needs migration
+        validated_statement = ValidatedStatement(
+            category=SQLQueryCategory.DDL,
+            command=SQLQueryCommand.CREATE,
+            risk_level=OperationRiskLevel.MEDIUM,
+            query="CREATE TABLE test (id INT)",
+            needs_migration=True,
+            object_type="TABLE",
+            schema_name="public",
+        )
+
+        validation_result = QueryValidationResults(
+            statements=[validated_statement],
+            highest_risk_level=OperationRiskLevel.MEDIUM,
+            has_transaction_control=False,
+            original_query="CREATE TABLE test (id INT)",
+        )
+
+        # Call the method
+        await query_manager.handle_migration(validation_result, "CREATE TABLE test (id INT)", "test_migration")
+
+        # Verify that the migration manager was called to prepare the migration query
+        migration_manager.prepare_migration_query.assert_called_once_with(
+            validation_result, "CREATE TABLE test (id INT)", "test_migration"
+        )
+
+        # Verify that execute_query was called at least twice
+        # Once for init_migration_schema and once for the migration query
+        assert postgres_client.execute_query.call_count >= 2

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -282,7 +282,7 @@ class TestDatabaseTools:
                         original_query=cleanup_query,
                     )
 
-                    await postgres_client.execute_query_async(validation_result, readonly=False)
+                    await postgres_client.execute_query(validation_result, readonly=False)
                     print(f"Cleaned up test migrations matching: {name_pattern}")
                 except Exception as e:
                     print(f"Failed to clean up test migrations: {e}")


### PR DESCRIPTION
 # Description

This commit primarily fixes a bug that prevented postgresql queries from being executed if a user didn't have `supabase_migrations` schema. Validated the fix with:
- deleting this schema
- running a query that triggers migration
- validating the schema and table is successfully created.

Other changes in this PR:
- Added SQLLoader to centralize SQL query loading and management
- Implemented new migration initialization and creation queries
- Updated PostgresClient error handling and query execution methods
- Expanded test coverage for migration and query management components

Closes #44.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Code refactoring (no functional changes)


## Checklist
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
