### PR TITLE
feat(logs): introduce retrieve_logs tool

### DIFF
--- a/.github/workflows/docs/release-checklist.md
+++ b/.github/workflows/docs/release-checklist.md
@@ -16,6 +16,23 @@ Post-release
 - Clean install from PyPi works
 
 
+## v0.3.12 - 2025-03-12
+
+Pre-release
+1. Tests pass - []
+2. CI passes - []
+3. Build succeeds - []
+4. Documentation is up to date - []
+5. Changelog is up to date - []
+6. Tag and release on GitHub
+7. Release is published to PyPI
+8. Update dockerfile - []
+9. Update .env.example (if necessary) - []
+
+Post-release
+10. Clean install from PyPi works - []
+
+
 ## v0.3.8 - 2025-03-07
 
 Pre-release

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,8 @@ Icon
 # Local development
 
 *.log
-logs/
+# Only ignore logs directory in the root, not in the package
+/logs/
 
 
 # Ignore local assets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,10 +120,10 @@ repos:
         pass_filenames: false
         args: [
           "--no-header",
-          "-v",
           "--quiet",
           "--no-summary",
-          "--show-capture=no"
+          "--show-capture=no",
+          "--tb=line"  # Show only one line per failure
         ]
         stages: [pre-commit, pre-push]
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## [0.3.12] - 2025-03-12
+### Added
+- Implemented a new `retrieve_logs` tool that allows retrieval of logs from any Supabase log collection - Postgres, PostgREST, Auth, Edge Functions and others. Provides a way to query and filter
+- Implemented log rotation to prevent unbounded log file growth (5MB limit with 3 backup files)
+
+### Changed
+- Improved region configuration with clearer error messages for region mismatches
+- Updated smithery.yaml to reduce configuration error rate (Tenant not found)
+- Improved PostgreSQL client connection error handling with specific guidance for "Tenant or user not found" errors
+
+
 ## [0.3.11] - 2025-03-10
 ### Fixed
 - Fixed an error with creating a migration file when a user doesn't have `supabase_migrations` schema

--- a/README.md
+++ b/README.md
@@ -120,13 +120,15 @@ The server uses the following environment variables:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `SUPABASE_PROJECT_REF` | No | `127.0.0.1:54322` | Your Supabase project reference ID (or local host:port) |
-| `SUPABASE_DB_PASSWORD` | No | `postgres` | Your database password |
-| `SUPABASE_REGION` | No | `us-east-1` | AWS region where your Supabase project is hosted |
+| `SUPABASE_PROJECT_REF` | Yes | `127.0.0.1:54322` | Your Supabase project reference ID (or local host:port) |
+| `SUPABASE_DB_PASSWORD` | Yes | `postgres` | Your database password |
+| `SUPABASE_REGION` | Yes* | `us-east-1` | AWS region where your Supabase project is hosted |
 | `SUPABASE_ACCESS_TOKEN` | No | None | Personal access token for Supabase Management API |
 | `SUPABASE_SERVICE_ROLE_KEY` | No | None | Service role key for Auth Admin SDK |
 
 > **Note**: The default values are configured for local Supabase development. For remote Supabase projects, you must provide your own values for `SUPABASE_PROJECT_REF` and `SUPABASE_DB_PASSWORD`.
+
+> 🚨 **CRITICAL CONFIGURATION NOTE**: For remote Supabase projects, you MUST specify the correct region where your project is hosted using `SUPABASE_REGION`. If you encounter a "Tenant or user not found" error, this is almost certainly because your region setting doesn't match your project's actual region. You can find your project's region in the Supabase dashboard under Project Settings.
 
 #### Connection Types
 
@@ -491,6 +493,28 @@ The Auth Admin SDK provides several key advantages over direct SQL manipulation:
       - `magiclink` and `recovery` links require the user to already exist in the system
     - Error handling: The server provides detailed error messages from the Supabase API, which may differ from the dashboard interface
     - Method availability: Some methods like `delete_factor` are exposed in the API but not fully implemented in the SDK
+
+### Logs & Analytics
+
+The server provides access to Supabase logs and analytics data, making it easier to monitor and troubleshoot your applications:
+
+- **Available Tool**: `retrieve_logs` - Access logs from any Supabase service
+
+- **Log Collections**:
+  - `postgres`: Database server logs
+  - `api_gateway`: API gateway requests
+  - `auth`: Authentication events
+  - `postgrest`: RESTful API service logs
+  - `pooler`: Connection pooling logs
+  - `storage`: Object storage operations
+  - `realtime`: WebSocket subscription logs
+  - `edge_functions`: Serverless function executions
+  - `cron`: Scheduled job logs
+  - `pgbouncer`: Connection pooler logs
+
+- **Features**: Filter by time, search text, apply field filters, or use custom SQL queries
+
+Simplifies debugging across your Supabase stack without switching between interfaces or writing complex queries.
 
 ### Automatic Versioning of Database Changes
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -10,6 +10,7 @@ startCommand:
     required:
       - supabaseProjectRef
       - supabaseDbPassword
+      - supabaseRegion
     properties:
       supabaseProjectRef:
         type: string
@@ -21,8 +22,7 @@ startCommand:
         default: "postgres"
       supabaseRegion:
         type: string
-        description: "(optional) - AWS region where your Supabase project is hosted - Default: us-east-1"
-        default: "us-east-1"
+        description: "(required) - AWS region where your Supabase project is hosted - Default: us-east-1"
       supabaseAccessToken:
         type: string
         description: "(optional) - Personal access token for Supabase Management API - Default: none"

--- a/supabase_mcp/core/container.py
+++ b/supabase_mcp/core/container.py
@@ -5,6 +5,7 @@ from supabase_mcp.services.api.api_client import ManagementAPIClient
 from supabase_mcp.services.api.api_manager import SupabaseApiManager
 from supabase_mcp.services.database.postgres_client import PostgresClient
 from supabase_mcp.services.database.query_manager import QueryManager
+from supabase_mcp.services.logs.log_manager import LogManager
 from supabase_mcp.services.safety.safety_manager import SafetyManager
 from supabase_mcp.services.sdk.sdk_client import SupabaseSDKClient
 from supabase_mcp.settings import Settings
@@ -22,6 +23,7 @@ class Container:
         safety_manager: SafetyManager | None = None,
         query_manager: QueryManager | None = None,
         tool_manager: ToolManager | None = None,
+        log_manager: LogManager | None = None,
     ) -> None:
         """Create a new container container reference"""
         self.mcp_server = mcp_server
@@ -32,6 +34,7 @@ class Container:
         self.safety_manager = safety_manager
         self.query_manager = query_manager
         self.tool_manager = tool_manager
+        self.log_manager = log_manager
 
     def initialize(self, settings: Settings) -> "Container":
         """Initializes all services in a synchronous manner to satisfy MCP runtime requirements"""

--- a/supabase_mcp/logger.py
+++ b/supabase_mcp/logger.py
@@ -1,9 +1,10 @@
 import logging
+import logging.handlers
 from pathlib import Path
 
 
 def setup_logger() -> logging.Logger:
-    """Configure logging for the MCP server."""
+    """Configure logging for the MCP server with log rotation."""
     logger = logging.getLogger("supabase-mcp")
 
     # Remove existing handlers to avoid duplicate logs
@@ -17,8 +18,15 @@ def setup_logger() -> logging.Logger:
     # Define the log file path
     log_file = log_dir / "mcp_server.log"
 
-    # Create a file handler (only logs to file, no stdout)
-    file_handler = logging.FileHandler(log_file)
+    # Create a rotating file handler
+    # - Rotate when log reaches 5MB
+    # - Keep 3 backup files
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_file,
+        maxBytes=5 * 1024 * 1024,  # 5MB
+        backupCount=3,
+        encoding="utf-8",
+    )
 
     # Create formatter
     formatter = logging.Formatter("[%(asctime)s] %(levelname)-8s %(message)s", datefmt="%y/%m/%d %H:%M:%S")

--- a/supabase_mcp/services/database/sql/queries/logs/auth_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/auth_logs.sql
@@ -1,0 +1,13 @@
+SELECT 
+  id, 
+  auth_logs.timestamp, 
+  event_message,
+  metadata.level,
+  metadata.status,
+  metadata.path,
+  metadata.msg
+FROM auth_logs
+CROSS JOIN unnest(metadata) AS metadata
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/cron_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/cron_logs.sql
@@ -1,0 +1,15 @@
+SELECT 
+  id, 
+  postgres_logs.timestamp, 
+  event_message,
+  identifier,
+  parsed.error_severity,
+  parsed.query,
+  parsed.application_name
+FROM postgres_logs
+CROSS JOIN unnest(metadata) AS m
+CROSS JOIN unnest(m.parsed) AS parsed
+WHERE (parsed.application_name = 'pg_cron' OR event_message LIKE '%cron job%')
+{and_where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/edge_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/edge_logs.sql
@@ -1,0 +1,17 @@
+SELECT 
+  id, 
+  edge_logs.timestamp, 
+  event_message,
+  identifier,
+  request.method,
+  request.path,
+  response.status_code,
+  request.url,
+  response.origin_time
+FROM edge_logs
+CROSS JOIN unnest(metadata) AS m
+CROSS JOIN unnest(m.request) AS request
+CROSS JOIN unnest(m.response) AS response
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/function_edge_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/function_edge_logs.sql
@@ -1,0 +1,21 @@
+SELECT 
+  id, 
+  function_edge_logs.timestamp, 
+  event_message,
+  m.deployment_id,
+  m.execution_time_ms,
+  m.function_id,
+  m.project_ref,
+  request.method,
+  request.pathname,
+  request.url,
+  request.host,
+  response.status_code,
+  m.version
+FROM function_edge_logs
+CROSS JOIN unnest(metadata) AS m
+CROSS JOIN unnest(m.request) AS request
+CROSS JOIN unnest(m.response) AS response
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/pgbouncer_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/pgbouncer_logs.sql
@@ -1,0 +1,11 @@
+SELECT 
+  id, 
+  pgbouncer_logs.timestamp, 
+  event_message,
+  metadata.host,
+  metadata.project
+FROM pgbouncer_logs
+CROSS JOIN unnest(metadata) AS metadata
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/postgres_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/postgres_logs.sql
@@ -1,0 +1,14 @@
+SELECT 
+  id, 
+  postgres_logs.timestamp, 
+  event_message,
+  identifier,
+  parsed.error_severity,
+  parsed.query,
+  parsed.application_name
+FROM postgres_logs
+CROSS JOIN unnest(metadata) AS m
+CROSS JOIN unnest(m.parsed) AS parsed
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit};  

--- a/supabase_mcp/services/database/sql/queries/logs/postgrest_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/postgrest_logs.sql
@@ -1,0 +1,11 @@
+SELECT 
+  id, 
+  postgrest_logs.timestamp, 
+  event_message,
+  identifier,
+  metadata.host
+FROM postgrest_logs
+CROSS JOIN unnest(metadata) AS metadata
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/realtime_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/realtime_logs.sql
@@ -1,0 +1,16 @@
+SELECT 
+  id, 
+  realtime_logs.timestamp, 
+  event_message,
+  metadata.level,
+  measurements.connected,
+  measurements.connected_cluster,
+  measurements.limit,
+  measurements.sum,
+  metadata.external_id
+FROM realtime_logs
+CROSS JOIN unnest(metadata) AS metadata
+CROSS JOIN unnest(metadata.measurements) AS measurements
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/storage_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/storage_logs.sql
@@ -1,0 +1,13 @@
+SELECT 
+  id, 
+  storage_logs.timestamp, 
+  event_message,
+  metadata.level,
+  metadata.project,
+  metadata.responseTime,
+  metadata.rawError
+FROM storage_logs
+CROSS JOIN unnest(metadata) AS metadata
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/database/sql/queries/logs/supavisor_logs.sql
+++ b/supabase_mcp/services/database/sql/queries/logs/supavisor_logs.sql
@@ -1,0 +1,12 @@
+SELECT 
+  id, 
+  supavisor_logs.timestamp, 
+  event_message,
+  metadata.level,
+  metadata.project,
+  metadata.region
+FROM supavisor_logs
+CROSS JOIN unnest(metadata) AS metadata
+{where_clause}
+ORDER BY timestamp DESC
+LIMIT {limit}; 

--- a/supabase_mcp/services/logs/log_manager.py
+++ b/supabase_mcp/services/logs/log_manager.py
@@ -1,0 +1,128 @@
+from typing import Any
+
+from supabase_mcp.logger import logger
+from supabase_mcp.services.database.sql.loader import SQLLoader
+
+
+class LogManager:
+    """Manager for retrieving logs from Supabase services."""
+
+    # Map collection names to table names
+    COLLECTION_TO_TABLE = {
+        "postgres": "postgres_logs",
+        "api_gateway": "edge_logs",
+        "auth": "auth_logs",
+        "postgrest": "postgrest_logs",
+        "pooler": "supavisor_logs",
+        "storage": "storage_logs",
+        "realtime": "realtime_logs",
+        "edge_functions": "function_edge_logs",
+        "cron": "postgres_logs",
+        "pgbouncer": "pgbouncer_logs",
+    }
+
+    def __init__(self) -> None:
+        """Initialize the LogManager."""
+        self.sql_loader = SQLLoader()
+
+    def _build_where_clause(
+        self,
+        collection: str,
+        hours_ago: int | None = None,
+        filters: list[dict[str, Any]] | None = None,
+        search: str | None = None,
+    ) -> str:
+        """Build the WHERE clause for a log query.
+
+        Args:
+            collection: The log collection name
+            hours_ago: Number of hours to look back
+            filters: List of filter objects with field, operator, and value
+            search: Text to search for in event messages
+
+        Returns:
+            The WHERE clause as a string
+        """
+        logger.debug(
+            f"Building WHERE clause for collection={collection}, hours_ago={hours_ago}, filters={filters}, search={search}"
+        )
+
+        clauses = []
+
+        # Get the table name for this collection
+        table_name = self.COLLECTION_TO_TABLE.get(collection, collection)
+
+        # Add time filter using BigQuery's TIMESTAMP_SUB function
+        if hours_ago:
+            # Qualify the timestamp column with the table name to avoid ambiguity
+            clauses.append(f"{table_name}.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {hours_ago} HOUR)")
+
+        # Add search filter
+        if search:
+            # Escape single quotes in search text
+            search_escaped = search.replace("'", "''")
+            clauses.append(f"event_message LIKE '%{search_escaped}%'")
+
+        # Add custom filters
+        if filters:
+            for filter_obj in filters:
+                field = filter_obj["field"]
+                operator = filter_obj["operator"]
+                value = filter_obj["value"]
+
+                # Handle string values
+                if isinstance(value, str) and not value.isdigit():
+                    value = f"'{value.replace("'", "''")}'"
+
+                clauses.append(f"{field} {operator} {value}")
+
+        # For cron logs, we already have a WHERE clause in the template
+        if collection == "cron":
+            if clauses:
+                where_clause = f"AND {' AND '.join(clauses)}"
+            else:
+                where_clause = ""
+        else:
+            if clauses:
+                where_clause = f"WHERE {' AND '.join(clauses)}"
+            else:
+                where_clause = ""
+
+        logger.debug(f"Built WHERE clause: {where_clause}")
+        return where_clause
+
+    def build_logs_query(
+        self,
+        collection: str,
+        limit: int = 20,
+        hours_ago: int | None = 1,
+        filters: list[dict[str, Any]] | None = None,
+        search: str | None = None,
+        custom_query: str | None = None,
+    ) -> str:
+        """Build a query for retrieving logs from a Supabase service.
+
+        Args:
+            collection: The log collection to query
+            limit: Maximum number of log entries to return
+            hours_ago: Retrieve logs from the last N hours
+            filters: List of filter objects with field, operator, and value
+            search: Text to search for in event messages
+            custom_query: Complete custom SQL query to execute
+
+        Returns:
+            The SQL query string
+
+        Raises:
+            ValueError: If the collection is unknown
+        """
+        if custom_query:
+            return custom_query
+
+        # Build the WHERE clause
+        where_clause = self._build_where_clause(
+            collection=collection, hours_ago=hours_ago, filters=filters, search=search
+        )
+
+        # Get the SQL query
+        return self.sql_loader.get_logs_query(collection=collection, where_clause=where_clause, limit=limit)

--- a/supabase_mcp/tools/descriptions/logs_and_analytics_tools.yaml
+++ b/supabase_mcp/tools/descriptions/logs_and_analytics_tools.yaml
@@ -1,0 +1,69 @@
+# Tools related to logs and Advisor analytics
+
+retrieve_logs: |
+  Retrieve logs from your Supabase project's services for debugging and monitoring.
+
+  Returns log entries from various Supabase services with timestamps, messages, and metadata.
+  This tool provides access to the same logs available in the Supabase dashboard's Logs & Analytics section.
+
+  AVAILABLE LOG COLLECTIONS:
+  - postgres: Database server logs including queries, errors, warnings, and system messages
+  - api_gateway: API requests, responses, and errors processed by the Kong API gateway
+  - auth: Authentication and authorization logs for sign-ups, logins, and token operations
+  - postgrest: Logs from the RESTful API service that exposes your PostgreSQL database
+  - pooler: Connection pooling logs from pgbouncer and supavisor services
+  - storage: Object storage service logs for file uploads, downloads, and permissions
+  - realtime: Logs from the real-time subscription service for WebSocket connections
+  - edge_functions: Serverless function execution logs including invocations and errors
+  - cron: Scheduled job logs (can be queried through postgres logs with specific filters)
+  - pgbouncer: Connection pooler logs
+
+  PARAMETERS:
+  - collection: The log collection to query (required, one of the values listed above)
+  - limit: Maximum number of log entries to return (default: 20)
+  - hours_ago: Retrieve logs from the last N hours (default: 1)
+  - filters: List of filter objects with field, operator, and value (default: [])
+    Format: [{"field": "field_name", "operator": "=", "value": "value"}]
+  - search: Text to search for in event messages (default: "")
+  - custom_query: Complete custom SQL query to execute instead of the pre-built queries (default: "")
+
+  HOW IT WORKS:
+  This tool makes a request to the Supabase Management API endpoint for logs, sending
+  either a pre-built optimized query for the selected collection or your custom query.
+  Each log collection has a specific table structure and metadata format that requires
+  appropriate CROSS JOIN UNNEST operations to access nested fields.
+
+  EXAMPLES:
+  1. Using pre-built parameters:
+     collection: "postgres"
+     limit: 20
+     hours_ago: 24
+     filters: [{"field": "parsed.error_severity", "operator": "=", "value": "ERROR"}]
+     search: "connection"
+
+  2. Using a custom query:
+     collection: "edge_functions"
+     custom_query: "SELECT id, timestamp, event_message, m.function_id, m.execution_time_ms
+                   FROM function_edge_logs
+                   CROSS JOIN unnest(metadata) AS m
+                   WHERE m.execution_time_ms > 1000
+                   ORDER BY timestamp DESC LIMIT 10"
+
+  METADATA STRUCTURE:
+  The metadata structure is important because it determines how to access nested fields in filters:
+  - postgres_logs: Use "parsed.field_name" for fields like error_severity, query, application_name
+  - edge_logs: Use "request.field_name" or "response.field_name" for HTTP details
+  - function_edge_logs: Use "function_id", "execution_time_ms" for function metrics
+
+  NOTE FOR LLM CLIENTS:
+  When encountering errors with field access, examine the error message to see what fields are
+  actually available in the structure. Start with basic fields before accessing nested metadata.
+
+  SAFETY CONSIDERATIONS:
+  - This is a low-risk read operation that can be executed in SAFE mode
+  - Requires a valid Supabase Personal Access Token to be configured
+  - Not available for local Supabase instances (requires cloud deployment)
+
+
+retrieve_advisor_analytics: |
+  Get advisor analytics from the database.

--- a/supabase_mcp/tools/manager.py
+++ b/supabase_mcp/tools/manager.py
@@ -30,6 +30,10 @@ class ToolName(str, Enum):
     GET_AUTH_ADMIN_METHODS_SPEC = "get_auth_admin_methods_spec"
     CALL_AUTH_ADMIN_METHOD = "call_auth_admin_method"
 
+    # Logs & Analytics tools
+    GET_LOGS = "get_logs"
+    GET_QUERY_PERFORMANCE = "get_query_performance"
+
 
 class ToolManager:
     """Manager for tool descriptions and registration.

--- a/supabase_mcp/tools/manager.py
+++ b/supabase_mcp/tools/manager.py
@@ -31,8 +31,7 @@ class ToolName(str, Enum):
     CALL_AUTH_ADMIN_METHOD = "call_auth_admin_method"
 
     # Logs & Analytics tools
-    GET_LOGS = "get_logs"
-    GET_QUERY_PERFORMANCE = "get_query_performance"
+    RETRIEVE_LOGS = "retrieve_logs"
 
 
 class ToolManager:

--- a/supabase_mcp/tools/registry.py
+++ b/supabase_mcp/tools/registry.py
@@ -165,4 +165,32 @@ class ToolRegistry:
             elif operation_type == "database":
                 return await query_manager.handle_confirmation(confirmation_id)
 
+        @mcp.tool(description=tool_manager.get_description(ToolName.RETRIEVE_LOGS))  # type: ignore
+        async def retrieve_logs(
+            collection: str,
+            limit: int = 20,
+            hours_ago: int = 1,
+            filters: list[dict[str, Any]] = [],
+            search: str = "",
+            custom_query: str = "",
+        ) -> dict[str, Any]:
+            """Retrieve logs from your Supabase project's services for debugging and monitoring."""
+            logger.info(
+                f"Tool called: retrieve_logs(collection={collection}, limit={limit}, hours_ago={hours_ago}, filters={filters}, search={search}, custom_query={'<custom>' if custom_query else None})"
+            )
+
+            api_manager = services_container.api_manager
+            result = await api_manager.retrieve_logs(
+                collection=collection,
+                limit=limit,
+                hours_ago=hours_ago,
+                filters=filters,
+                search=search,
+                custom_query=custom_query,
+            )
+
+            logger.info(f"Tool completed: retrieve_logs - Retrieved log entries for collection={collection}")
+
+            return result
+
         return mcp

--- a/tests/services/logs/test_log_manager.py
+++ b/tests/services/logs/test_log_manager.py
@@ -1,0 +1,206 @@
+from unittest.mock import patch
+
+import pytest
+
+from supabase_mcp.services.database.sql.loader import SQLLoader
+from supabase_mcp.services.logs.log_manager import LogManager
+
+
+class TestLogManager:
+    """Tests for the LogManager class."""
+
+    def test_init(self):
+        """Test initialization of LogManager."""
+        log_manager = LogManager()
+        assert isinstance(log_manager.sql_loader, SQLLoader)
+        assert log_manager.COLLECTION_TO_TABLE["postgres"] == "postgres_logs"
+        assert log_manager.COLLECTION_TO_TABLE["api_gateway"] == "edge_logs"
+        assert log_manager.COLLECTION_TO_TABLE["edge_functions"] == "function_edge_logs"
+
+    @pytest.mark.parametrize(
+        "collection,hours_ago,filters,search,expected_clause",
+        [
+            # Test with hours_ago only
+            (
+                "postgres",
+                24,
+                None,
+                None,
+                "WHERE postgres_logs.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)",
+            ),
+            # Test with search only
+            (
+                "auth",
+                None,
+                None,
+                "error",
+                "WHERE event_message LIKE '%error%'",
+            ),
+            # Test with filters only
+            (
+                "api_gateway",
+                None,
+                [{"field": "status_code", "operator": "=", "value": 500}],
+                None,
+                "WHERE status_code = 500",
+            ),
+            # Test with string value in filters
+            (
+                "api_gateway",
+                None,
+                [{"field": "method", "operator": "=", "value": "GET"}],
+                None,
+                "WHERE method = 'GET'",
+            ),
+            # Test with multiple filters
+            (
+                "postgres",
+                None,
+                [
+                    {"field": "parsed.error_severity", "operator": "=", "value": "ERROR"},
+                    {"field": "parsed.application_name", "operator": "LIKE", "value": "app%"},
+                ],
+                None,
+                "WHERE parsed.error_severity = 'ERROR' AND parsed.application_name LIKE 'app%'",
+            ),
+            # Test with hours_ago and search
+            (
+                "storage",
+                12,
+                None,
+                "upload",
+                "WHERE storage_logs.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR) AND event_message LIKE '%upload%'",
+            ),
+            # Test with all parameters
+            (
+                "edge_functions",
+                6,
+                [{"field": "response.status_code", "operator": ">", "value": 400}],
+                "timeout",
+                "WHERE function_edge_logs.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 6 HOUR) AND event_message LIKE '%timeout%' AND response.status_code > 400",
+            ),
+            # Test with cron logs (special case)
+            (
+                "cron",
+                24,
+                None,
+                None,
+                "AND postgres_logs.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)",
+            ),
+            # Test with cron logs and other parameters
+            (
+                "cron",
+                12,
+                [{"field": "parsed.error_severity", "operator": "=", "value": "ERROR"}],
+                "failed",
+                "AND postgres_logs.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR) AND event_message LIKE '%failed%' AND parsed.error_severity = 'ERROR'",
+            ),
+        ],
+    )
+    def test_build_where_clause(self, collection, hours_ago, filters, search, expected_clause):
+        """Test building WHERE clauses for different scenarios."""
+        log_manager = LogManager()
+        where_clause = log_manager._build_where_clause(
+            collection=collection, hours_ago=hours_ago, filters=filters, search=search
+        )
+        assert where_clause == expected_clause
+
+    def test_build_where_clause_escapes_single_quotes(self):
+        """Test that single quotes in search strings are properly escaped."""
+        log_manager = LogManager()
+        where_clause = log_manager._build_where_clause(collection="postgres", search="O'Reilly")
+        assert where_clause == "WHERE event_message LIKE '%O''Reilly%'"
+
+        # Test with filters containing single quotes
+        where_clause = log_manager._build_where_clause(
+            collection="postgres",
+            filters=[{"field": "parsed.query", "operator": "LIKE", "value": "SELECT * FROM O'Reilly"}],
+        )
+        assert where_clause == "WHERE parsed.query LIKE 'SELECT * FROM O''Reilly'"
+
+    @patch.object(SQLLoader, "get_logs_query")
+    def test_build_logs_query_with_custom_query(self, mock_get_logs_query):
+        """Test building a logs query with a custom query."""
+        log_manager = LogManager()
+        custom_query = "SELECT * FROM postgres_logs LIMIT 10"
+
+        query = log_manager.build_logs_query(collection="postgres", custom_query=custom_query)
+
+        assert query == custom_query
+        # Ensure get_logs_query is not called when custom_query is provided
+        mock_get_logs_query.assert_not_called()
+
+    @patch.object(LogManager, "_build_where_clause")
+    @patch.object(SQLLoader, "get_logs_query")
+    def test_build_logs_query_standard(self, mock_get_logs_query, mock_build_where_clause):
+        """Test building a standard logs query."""
+        log_manager = LogManager()
+        mock_build_where_clause.return_value = "WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)"
+        mock_get_logs_query.return_value = "SELECT * FROM postgres_logs WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR) LIMIT 20"
+
+        query = log_manager.build_logs_query(
+            collection="postgres",
+            limit=20,
+            hours_ago=24,
+            filters=[{"field": "parsed.error_severity", "operator": "=", "value": "ERROR"}],
+            search="connection",
+        )
+
+        mock_build_where_clause.assert_called_once_with(
+            collection="postgres",
+            hours_ago=24,
+            filters=[{"field": "parsed.error_severity", "operator": "=", "value": "ERROR"}],
+            search="connection",
+        )
+
+        mock_get_logs_query.assert_called_once_with(
+            collection="postgres",
+            where_clause="WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)",
+            limit=20,
+        )
+
+        assert (
+            query
+            == "SELECT * FROM postgres_logs WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR) LIMIT 20"
+        )
+
+    @patch.object(SQLLoader, "get_logs_query")
+    def test_build_logs_query_integration(self, mock_get_logs_query, sql_loader):
+        """Test building a logs query with integration between components."""
+        # Setup
+        log_manager = LogManager()
+        log_manager.sql_loader = sql_loader
+
+        # Mock the SQL loader to return a predictable result
+        mock_get_logs_query.return_value = (
+            "SELECT id, postgres_logs.timestamp, event_message FROM postgres_logs "
+            "WHERE postgres_logs.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR) "
+            "ORDER BY timestamp DESC LIMIT 10"
+        )
+
+        # Execute
+        query = log_manager.build_logs_query(
+            collection="postgres",
+            limit=10,
+            hours_ago=24,
+        )
+
+        # Verify
+        assert "SELECT id, postgres_logs.timestamp, event_message FROM postgres_logs" in query
+        assert "LIMIT 10" in query
+        mock_get_logs_query.assert_called_once()
+
+    def test_unknown_collection(self):
+        """Test handling of unknown collections."""
+        log_manager = LogManager()
+
+        # Test with a collection that doesn't exist in the mapping
+        where_clause = log_manager._build_where_clause(
+            collection="unknown_collection",
+            hours_ago=24,
+        )
+
+        # Should use the collection name as the table name
+        assert (
+            where_clause == "WHERE unknown_collection.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)"
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,14 +76,15 @@ class TestMain:
             ToolName.GET_MANAGEMENT_API_SPEC,
             ToolName.GET_AUTH_ADMIN_METHODS_SPEC,
             ToolName.CALL_AUTH_ADMIN_METHOD,
+            ToolName.RETRIEVE_LOGS,
         ]
 
         # Verify tools are registered in MCP
         registered_tools = asyncio.run(mcp.list_tools())
         registered_tool_names = {tool.name for tool in registered_tools}
 
-        # We should have exactly 11 tools (all the tools defined in ToolName enum)
-        assert len(registered_tools) == 11, f"Expected 11 tools, but got {len(registered_tools)}"
+        # We should have exactly 12 tools (all the tools defined in ToolName enum)
+        assert len(registered_tools) == 12, f"Expected 12 tools, but got {len(registered_tools)}"
 
         # Log the actual number of tools for reference
         logger.info(f"Found {len(registered_tools)} MCP tools registered")

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -165,3 +165,20 @@ class TestToolManager:
         # Reset the singleton for other tests
         # pylint: disable=protected-access
         ToolManager._instance = None  # type: ignore
+
+    def test_tool_enum_completeness(self):
+        """Test that the ToolName enum contains all expected tools."""
+        # Get all tool values from the enum
+        tool_values = [tool.value for tool in ToolName]
+
+        # Verify the total number of tools
+        # Update this number when new tools are added
+        expected_tool_count = 12
+        assert len(tool_values) == expected_tool_count, f"Expected {expected_tool_count} tools, got {len(tool_values)}"
+
+        # Verify specific tools are included
+        assert "retrieve_logs" in tool_values, "retrieve_logs tool is missing from ToolName enum"
+
+        # Reset the singleton for other tests
+        # pylint: disable=protected-access
+        ToolManager._instance = None  # type: ignore


### PR DESCRIPTION
 # retrieve_logs tool: access 10 Supabase log collections with filters and custom queries support

This PR introduces support for a new class of Logs & Analytics tools. The first tool in the series `retrieve_logs` tool allows users to easily retrieve logs from any log collection in Supabase, such as Auth, Postgres, PostgREST, Edge functions and many others. This will greatly aid in debugging and working with Supabase instance from the IDE / MCP client.

Other changes included in the PR:
- added file logger rotation (5MB) 
- updated warnings and error messages and updated documentation to clarify `SUPABASE_DB_REGION` is required when connecting to a remote Supabase instance

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [X] Test updates


## Checklist
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
