### PR TITLE
feat: allow extra environment variables in settings

### DIFF
--- a/supabase_mcp/settings.py
+++ b/supabase_mcp/settings.py
@@ -60,6 +60,8 @@ def find_config_file(env_file: str = ".env") -> str | None:
 
 class Settings(BaseSettings):
     """Initializes settings for Supabase MCP server."""
+    
+    model_config = SettingsConfigDict(extra='ignore')  # Allow extra fields in env file
 
     supabase_project_ref: str = Field(
         default="127.0.0.1:54322",  # Local Supabase default


### PR DESCRIPTION
 # Description

This PR modifies the Settings class to allow extra fields in the environment file. This change enables the MCP server to work with environment files that contain additional variables not used by the server itself.

Changes:
- Added `model_config = SettingsConfigDict(extra='ignore')` to the Settings class to allow extra fields in environment files

This fixes an issue where the server would fail to start if the environment file contained variables used by other applications.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Test updates
- [ ] CI/CD or build process changes
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
